### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/raf555/kbbi-api/security/code-scanning/2](https://github.com/raf555/kbbi-api/security/code-scanning/2)

In general, the problem is fixed by adding an explicit `permissions:` section that limits the `GITHUB_TOKEN` to the minimal scopes needed. For this workflow, all steps are read‑only with respect to the repository; they only need to fetch the code and run Go tooling. Therefore, the least‑privilege setting is `contents: read`. This can be defined at the workflow root (applies to all jobs) or at the job level. Since there is only one job, either location is fine; placing it at the top level makes intent clear and is consistent with GitHub’s examples.

The single best fix without changing existing functionality is to add a root‑level `permissions:` block after the `on:` section, specifying `contents: read`. No other permissions (such as `pull-requests` or `issues`) are needed, since there is no action that writes to PRs or issues. Concretely, edit `.github/workflows/go.yml` to insert:

```yml
permissions:
  contents: read
```

between the `on:` block (lines 3–7) and the `jobs:` block (line 9). No imports or additional definitions are required because this is a YAML configuration change only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
