### PR TITLE
feat(go): upgrade to go 1.26

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache: true
 
       - name: Build
@@ -31,4 +31,5 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.6
+          version: v2.11.2
+          only-new-issues: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25 AS builder
+FROM golang:1.26 AS builder
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/raf555/kbbi-api
 
 replace github.com/raf555/kbbi-api/pkg/kbbi => ./pkg/kbbi
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/gin-gonic/gin v1.11.0

--- a/internal/http/httpsrv/server.go
+++ b/internal/http/httpsrv/server.go
@@ -29,6 +29,7 @@ func NewServer(param ServerParam) *http.Server {
 	g := gin.New()
 	g.ContextWithFallback = true
 	g.UseRawPath = true
+	g.TrustedPlatform = gin.PlatformCloudflare // this service is run behind CF
 
 	logger := param.Slog.With(slog.String("label", "http_server"))
 
@@ -47,12 +48,6 @@ func NewServer(param ServerParam) *http.Server {
 }
 
 func registerMiddlewares(cfg config.ServerConfig, router *gin.Engine, logger *slog.Logger) {
-	router.Use(sloggin.NewWithConfig(logger, sloggin.Config{
-		Filters: []sloggin.Filter{
-			sloggin.IgnorePathContains("/healthzzz"),
-		},
-	}))
-
 	router.Use(otelgin.Middleware(cfg.ServiceName,
 		otelgin.WithGinFilter(
 			func(c *gin.Context) bool {
@@ -63,6 +58,15 @@ func registerMiddlewares(cfg config.ServerConfig, router *gin.Engine, logger *sl
 			},
 		),
 	))
+
+	router.Use(sloggin.NewWithConfig(logger, sloggin.Config{
+		Filters: []sloggin.Filter{
+			sloggin.IgnorePathContains("/healthzzz"),
+		},
+		WithTraceID:   true,
+		WithSpanID:    true,
+		WithUserAgent: true,
+	}))
 
 	router.Use(gin.CustomRecovery(func(ctx *gin.Context, err any) {
 		logger.ErrorContext(ctx, "Panic occurred", slog.Any("panic", err))


### PR DESCRIPTION
and reorder trace middleware