### PR TITLE
feat(dictionary): add raw option for entry APIs for raw HTTP tags and add isPrecategorical field

### DIFF
--- a/assets/dict.db
+++ b/assets/dict.db
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cf3e680bd49805a2b92b753b5fbff18c58dbce7a75283f4fbcd9d974418b4b24
-size 12518919
+oid sha256:b8c532b07b6b0be916b6a1f8d7e410de6feeee362fcda607927e9b6b4ef3164b
+size 14257973

--- a/internal/dictionary/dictionary.go
+++ b/internal/dictionary/dictionary.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/raf555/kbbi-api/pkg/kbbi"
 	"github.com/samber/lo"
 )
 
@@ -27,7 +26,7 @@ type lemmaIndex struct {
 }
 
 type wrappedLemma struct {
-	kbbi.Lemma
+	Lemma
 
 	NormalizedForm string
 }
@@ -113,37 +112,37 @@ func (d *Dictionary) Stats() Stats {
 	return d.stats
 }
 
-func (d *Dictionary) Lemma(lemma string, entryNo int) (kbbi.Lemma, error) {
+func (d *Dictionary) Lemma(lemma string, entryNo int) (Lemma, error) {
 	if lemma == "" {
-		return kbbi.Lemma{}, ErrUnexpectedEmptyLemma
+		return Lemma{}, ErrUnexpectedEmptyLemma
 	}
 
 	if len(lemma) > d.longestLemmaLength {
-		return kbbi.Lemma{}, ErrLemmaTooLong
+		return Lemma{}, ErrLemmaTooLong
 	}
 
 	index := d.lookupInverseIndex(lemma)
 	if index == nil {
-		return kbbi.Lemma{}, ErrLemmaNotFound
+		return Lemma{}, ErrLemmaNotFound
 	}
 
 	lemmaData := d.lemmas[index.idx]
 
 	if entryNo < 0 {
-		return kbbi.Lemma{}, ErrUnexpectedEntryNumber
+		return Lemma{}, ErrUnexpectedEntryNumber
 	}
 
 	if entryNo > 0 {
 		if entryNo > len(lemmaData.Entries) {
-			return kbbi.Lemma{}, ErrEntryNotFound
+			return Lemma{}, ErrEntryNotFound
 		}
 
 		entryIndexes, ok := index.entryNoMap[entryNo]
 		if !ok {
-			return kbbi.Lemma{}, ErrEntryNotFound
+			return Lemma{}, ErrEntryNotFound
 		}
 
-		lemmaData.Entries = lo.Map(entryIndexes, func(idx int, _ int) kbbi.Entry {
+		lemmaData.Entries = lo.Map(entryIndexes, func(idx int, _ int) Entry {
 			return lemmaData.Entries[idx]
 		})
 	}
@@ -169,17 +168,17 @@ func (d *Dictionary) lookupInverseIndex(lemma string) *lemmaIndex {
 	return nil
 }
 
-func (d *Dictionary) RandomLemma() kbbi.Lemma {
+func (d *Dictionary) RandomLemma() Lemma {
 	randomIdx := rand.IntN(len(d.lemmas))
 	return d.lemmas[randomIdx].Lemma
 }
 
-func (d *Dictionary) LemmaOfTheDay() (kbbi.Lemma, error) {
+func (d *Dictionary) LemmaOfTheDay() (Lemma, error) {
 	wotdIdx := d.wotd.TodayLemmaIndex()
 	idx := wotdIdx - 1
 
 	if !d.indexInDictRange(idx) {
-		return kbbi.Lemma{}, fmt.Errorf("%w: %d", ErrUnexpectedWotdIndex, idx)
+		return Lemma{}, fmt.Errorf("%w: %d", ErrUnexpectedWotdIndex, idx)
 	}
 
 	return d.lemmas[idx].Lemma, nil
@@ -189,9 +188,9 @@ func (d *Dictionary) LemmaOfTheDay() (kbbi.Lemma, error) {
 // Search behaves similarly with search feature on the KBBI application.
 //
 // If prefix is empty, Search returns top limit lemmas.
-func (d *Dictionary) Search(prefix string, limit uint) []kbbi.Lemma {
+func (d *Dictionary) Search(prefix string, limit uint) []Lemma {
 	if prefix == "" {
-		return lo.Map(d.lemmas[:min(int(limit), len(d.lemmas))], func(lemma wrappedLemma, _ int) kbbi.Lemma { return lemma.Lemma })
+		return lo.Map(d.lemmas[:min(int(limit), len(d.lemmas))], func(lemma wrappedLemma, _ int) Lemma { return lemma.Lemma })
 	}
 
 	prefix = strings.ToLower(Normalize(prefix, true))
@@ -208,5 +207,5 @@ func (d *Dictionary) Search(prefix string, limit uint) []kbbi.Lemma {
 		return nil
 	}
 
-	return lo.Map(d.lemmas[leftIdx:rightIdx][:min(limit, uint(rightIdx-leftIdx))], func(lemma wrappedLemma, _ int) kbbi.Lemma { return lemma.Lemma })
+	return lo.Map(d.lemmas[leftIdx:rightIdx][:min(limit, uint(rightIdx-leftIdx))], func(lemma wrappedLemma, _ int) Lemma { return lemma.Lemma })
 }

--- a/internal/dictionary/http_handler.go
+++ b/internal/dictionary/http_handler.go
@@ -125,7 +125,7 @@ func (h *HTTPHandler) Entry(ctx context.Context, req *EntryRequest) (*EntryRespo
 		}
 	}
 
-	return &EntryResponse{data.ToKBBI(req.RAW)}, nil
+	return &EntryResponse{data.ToKBBI(req.Raw)}, nil
 }
 
 // Entry godoc
@@ -145,9 +145,9 @@ func (h *HTTPHandler) Random(ctx context.Context, req *RandomRequest) (httphandl
 		Path: url.PathEscape(lemma.Lemma),
 	}
 
-	if req.RAW {
+	if req.Raw {
 		res.Query = url.Values{
-			"raw": []string{strconv.FormatBool(req.RAW)},
+			"raw": []string{strconv.FormatBool(req.Raw)},
 		}
 	}
 
@@ -174,9 +174,9 @@ func (h *HTTPHandler) WOTD(ctx context.Context, req *WOTDRequest) (httphandler.R
 		Path: url.PathEscape(wotd.Lemma),
 	}
 
-	if req.RAW {
+	if req.Raw {
 		res.Query = url.Values{
-			"raw": []string{strconv.FormatBool(req.RAW)},
+			"raw": []string{strconv.FormatBool(req.Raw)},
 		}
 	}
 

--- a/internal/dictionary/http_handler.go
+++ b/internal/dictionary/http_handler.go
@@ -11,7 +11,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/raf555/kbbi-api/internal/http/httperr"
 	"github.com/raf555/kbbi-api/internal/http/httphandler"
-	"github.com/raf555/kbbi-api/pkg/kbbi"
 	"github.com/raf555/salome/melt/metric"
 	"github.com/raf555/salome/melt/trace"
 	"github.com/samber/lo"
@@ -124,7 +123,7 @@ func (h *HTTPHandler) Entry(ctx context.Context, req *EntryRequest) (*EntryRespo
 		}
 	}
 
-	return &EntryResponse{data}, nil
+	return &EntryResponse{data.ToKBBI()}, nil
 }
 
 // Entry godoc
@@ -184,6 +183,6 @@ func (h *HTTPHandler) Search(ctx context.Context, req *SearchRequest) (*SearchRe
 	result := h.dict.Search(req.Lemma, req.Limit)
 
 	return &SearchResponse{
-		Lemmas: lo.Map(result, func(lemma kbbi.Lemma, _ int) string { return lemma.Lemma }),
+		Lemmas: lo.Map(result, func(lemma Lemma, _ int) string { return lemma.Lemma }),
 	}, nil
 }

--- a/internal/dictionary/http_handler.go
+++ b/internal/dictionary/http_handler.go
@@ -6,13 +6,12 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/raf555/kbbi-api/internal/http/httperr"
 	"github.com/raf555/kbbi-api/internal/http/httphandler"
-	"github.com/raf555/salome/melt/metric"
-	"github.com/raf555/salome/melt/trace"
 	"github.com/samber/lo"
 )
 
@@ -30,14 +29,16 @@ func (h *HTTPHandler) MustRegisterRoutes(g *gin.Engine) {
 	entryGroupV1 := g.Group("/api/v1/entry")
 
 	entryGroupV1.GET("/_random",
-		httphandler.MakeSimpleRedirectHandler(
+		httphandler.MakeRedirectHandler(
 			h.Random,
+			httphandler.DefaultRequestBinder,
 		),
 	)
 
 	entryGroupV1.GET("/_wotd",
-		httphandler.MakeSimpleRedirectHandler(
+		httphandler.MakeRedirectHandler(
 			h.WOTD,
+			httphandler.DefaultRequestBinder,
 		),
 	)
 
@@ -93,8 +94,9 @@ func (*HTTPHandler) redirectToLowercase(ctx *gin.Context) {
 // @Tags         entry
 // @Accept       json
 // @Produce      json
-// @Param        entry    path      string  true  "Lemma. E.g. apel, aku (2), etc."
-// @Param        entryNo  query     int	  	false "Lemma's entry number (optional). Start from 1. Will be skipped if there's entry number in the lemma." minimum(1)
+// @Param        entry    path      string  	true  	"Lemma. E.g. apel, aku (2), etc."
+// @Param        entryNo  query     int	  		false 	"Lemma's entry number (optional). Start from 1. Will be skipped if there's entry number in the lemma." minimum(1)
+// @Param        raw	  query     boolean		false	"if raw is true, any rendered unicode character (for 𝗯𝗼𝗹𝗱/𝘪𝘵𝘢𝘭𝘪𝘤/etc) will be replaced by HTML tags instead."
 // @Success      200   	  {object}  kbbi.Lemma
 // @Failure      400      {object}  httpres.Error
 // @Failure      404      {object}  httpres.Error
@@ -123,50 +125,62 @@ func (h *HTTPHandler) Entry(ctx context.Context, req *EntryRequest) (*EntryRespo
 		}
 	}
 
-	return &EntryResponse{data.ToKBBI()}, nil
+	return &EntryResponse{data.ToKBBI(req.RAW)}, nil
 }
 
 // Entry godoc
 // @Summary      Get Random Lemma
 // @Description  Redirect to the random lemma
 // @Tags         entry
+// @Param        raw	  query     boolean	  	false	"if raw is true, any rendered unicode character (for 𝗯𝗼𝗹𝗱/𝘪𝘵𝘢𝘭𝘪𝘤/etc) will be replaced by HTML tags instead."
 // @Success      200      {object}  kbbi.Lemma
 // @Success      302      {object}  kbbi.Lemma
 // @Failure      500      {object}  httpres.Error
 // @Router       /api/v1/entry/_random [get]
-func (h *HTTPHandler) Random(ctx context.Context) (httphandler.RedirectResult, error) {
-	ctx, span := trace.FromContext(ctx).Start(ctx, "dictionary.HTTPHandler/Random")
-	defer span.End()
-
+func (h *HTTPHandler) Random(ctx context.Context, req *RandomRequest) (httphandler.RedirectResult, error) {
 	lemma := h.dict.RandomLemma()
 
-	mt := metric.FromContext(ctx) // TODO: for metrics test, remove later
-	mt.Count(ctx, "kbbi_random", 1)
-
-	return httphandler.RedirectResult{
+	res := httphandler.RedirectResult{
 		Code: http.StatusFound,
 		Path: url.PathEscape(lemma.Lemma),
-	}, nil
+	}
+
+	if req.RAW {
+		res.Query = url.Values{
+			"raw": []string{strconv.FormatBool(req.RAW)},
+		}
+	}
+
+	return res, nil
 }
 
 // Entry godoc
 // @Summary      Get Lemma of The Day
 // @Description  Redirect to the lemma of the day
 // @Tags         entry
+// @Param        raw	  query     boolean	  	false	"if raw is true, any rendered unicode character (for 𝗯𝗼𝗹𝗱/𝘪𝘵𝘢𝘭𝘪𝘤/etc) will be replaced by HTML tags instead."
 // @Success      200      {object}  kbbi.Lemma
 // @Success      302      {object}  kbbi.Lemma
 // @Failure      500      {object}  httpres.Error
 // @Router       /api/v1/entry/_wotd [get]
-func (h *HTTPHandler) WOTD(ctx context.Context) (httphandler.RedirectResult, error) {
+func (h *HTTPHandler) WOTD(ctx context.Context, req *WOTDRequest) (httphandler.RedirectResult, error) {
 	wotd, err := h.dict.LemmaOfTheDay()
 	if err != nil {
 		return httphandler.RedirectResult{}, fmt.Errorf("h.dict.LemmaOfTheDay: %w", err)
 	}
 
-	return httphandler.RedirectResult{
+	res := httphandler.RedirectResult{
 		Code: http.StatusFound,
 		Path: url.PathEscape(wotd.Lemma),
-	}, nil
+	}
+
+	if req.RAW {
+		res.Query = url.Values{
+			"raw": []string{strconv.FormatBool(req.RAW)},
+		}
+	}
+
+	return res, nil
 }
 
 // Entry godoc

--- a/internal/dictionary/iface.go
+++ b/internal/dictionary/iface.go
@@ -1,15 +1,13 @@
 package dictionary
 
-import "github.com/raf555/kbbi-api/pkg/kbbi"
-
 type WOTDRepo interface {
 	RandomLemmaIndex() int
 	TodayLemmaIndex() int
 }
 
 type DictionaryRepo interface {
-	Lemma(lemma string, entryNo int) (kbbi.Lemma, error)
-	RandomLemma() kbbi.Lemma
-	LemmaOfTheDay() (kbbi.Lemma, error)
-	Search(prefix string, limit uint) []kbbi.Lemma
+	Lemma(lemma string, entryNo int) (Lemma, error)
+	RandomLemma() Lemma
+	LemmaOfTheDay() (Lemma, error)
+	Search(prefix string, limit uint) []Lemma
 }

--- a/internal/dictionary/lemma.go
+++ b/internal/dictionary/lemma.go
@@ -2,6 +2,7 @@ package dictionary
 
 import (
 	"github.com/raf555/kbbi-api/pkg/kbbi"
+	"github.com/samber/lo"
 )
 
 // internal representation of [kbbi.Lemma]
@@ -42,10 +43,10 @@ type (
 	}
 )
 
-func (l Lemma) ToKBBI() kbbi.Lemma {
+func (l Lemma) ToKBBI(raw bool) kbbi.Lemma {
 	entries := make([]kbbi.Entry, len(l.Entries))
 	for i := range l.Entries {
-		entries[i] = l.Entries[i].toKBBI()
+		entries[i] = l.Entries[i].toKBBI(raw)
 	}
 
 	return kbbi.Lemma{
@@ -54,10 +55,10 @@ func (l Lemma) ToKBBI() kbbi.Lemma {
 	}
 }
 
-func (e Entry) toKBBI() kbbi.Entry {
+func (e Entry) toKBBI(raw bool) kbbi.Entry {
 	definitions := make([]kbbi.EntryDefinition, len(e.Definitions))
 	for i := range e.Definitions {
-		definitions[i] = e.Definitions[i].toKBBI()
+		definitions[i] = e.Definitions[i].toKBBI(raw)
 	}
 
 	return kbbi.Entry{
@@ -76,17 +77,17 @@ func (e Entry) toKBBI() kbbi.Entry {
 	}
 }
 
-func (d EntryDefinition) toKBBI() kbbi.EntryDefinition {
+func (d EntryDefinition) toKBBI(raw bool) kbbi.EntryDefinition {
 	labels := make([]kbbi.EntryLabel, len(d.Labels))
 	for i := range d.Labels {
 		labels[i] = d.Labels[i].toKBBI()
 	}
 
 	return kbbi.EntryDefinition{
-		Definition:      d.Definition,
+		Definition:      lo.Ternary(raw, d.RawDefinition, d.Definition),
 		ReferencedLemma: d.ReferencedLemma,
 		Labels:          labels,
-		UsageExamples:   d.UsageExamples,
+		UsageExamples:   lo.Ternary(raw, d.RawUsageExamples, d.UsageExamples),
 	}
 }
 

--- a/internal/dictionary/lemma.go
+++ b/internal/dictionary/lemma.go
@@ -1,0 +1,99 @@
+package dictionary
+
+import (
+	"github.com/raf555/kbbi-api/pkg/kbbi"
+)
+
+// internal representation of [kbbi.Lemma]
+type (
+	Lemma struct {
+		Lemma   string  `json:"lemma"`
+		Entries []Entry `json:"entries"`
+	}
+
+	Entry struct {
+		Entry            string            `json:"entry"`
+		BaseWord         string            `json:"baseWord"`
+		EntryVariants    []string          `json:"entryVariants"`
+		Pronunciation    string            `json:"pronunciation"`
+		Definitions      []EntryDefinition `json:"definitions"`
+		NonStandardWords []string          `json:"nonStandardWords"`
+		WordVariants     []string          `json:"variants"`
+		CompoundWords    []string          `json:"compoundWords"`
+		DerivedWords     []string          `json:"derivedWords"`
+		Proverbs         []string          `json:"proverbs"`
+		Metaphors        []string          `json:"metaphors"`
+		IsPrecategorical bool              `json:"isPrecategorical"`
+	}
+
+	EntryDefinition struct {
+		Definition       string       `json:"definition"`
+		RawDefinition    string       `json:"rawDefinition"`
+		ReferencedLemma  string       `json:"referencedLemma"`
+		Labels           []EntryLabel `json:"labels"`
+		UsageExamples    []string     `json:"usageExamples"`
+		RawUsageExamples []string     `json:"rawUsageExamples"`
+	}
+
+	EntryLabel struct {
+		Code string `json:"code"`
+		Name string `json:"name"`
+		Kind string `json:"kind"`
+	}
+)
+
+func (l Lemma) ToKBBI() kbbi.Lemma {
+	entries := make([]kbbi.Entry, len(l.Entries))
+	for i := range l.Entries {
+		entries[i] = l.Entries[i].toKBBI()
+	}
+
+	return kbbi.Lemma{
+		Lemma:   l.Lemma,
+		Entries: entries,
+	}
+}
+
+func (e Entry) toKBBI() kbbi.Entry {
+	definitions := make([]kbbi.EntryDefinition, len(e.Definitions))
+	for i := range e.Definitions {
+		definitions[i] = e.Definitions[i].toKBBI()
+	}
+
+	return kbbi.Entry{
+		Entry:            e.Entry,
+		BaseWord:         e.BaseWord,
+		EntryVariants:    e.EntryVariants,
+		Pronunciation:    e.Pronunciation,
+		Definitions:      definitions,
+		NonStandardWords: e.NonStandardWords,
+		WordVariants:     e.WordVariants,
+		CompoundWords:    e.CompoundWords,
+		DerivedWords:     e.DerivedWords,
+		Proverbs:         e.Proverbs,
+		Metaphors:        e.Metaphors,
+		IsPrecategorical: e.IsPrecategorical,
+	}
+}
+
+func (d EntryDefinition) toKBBI() kbbi.EntryDefinition {
+	labels := make([]kbbi.EntryLabel, len(d.Labels))
+	for i := range d.Labels {
+		labels[i] = d.Labels[i].toKBBI()
+	}
+
+	return kbbi.EntryDefinition{
+		Definition:      d.Definition,
+		ReferencedLemma: d.ReferencedLemma,
+		Labels:          labels,
+		UsageExamples:   d.UsageExamples,
+	}
+}
+
+func (l EntryLabel) toKBBI() kbbi.EntryLabel {
+	return kbbi.EntryLabel{
+		Code: l.Code,
+		Name: l.Name,
+		Kind: l.Kind,
+	}
+}

--- a/internal/dictionary/models.go
+++ b/internal/dictionary/models.go
@@ -18,7 +18,8 @@ type Stats struct {
 type EntryRequest struct {
 	Lemma string `uri:"entry" validate:"required"`
 	// EntryNo is optional; value 0 means "no specific entry number requested".
-	EntryNo int `form:"entryNo" validate:"gte=0"`
+	EntryNo int  `form:"entryNo" validate:"gte=0"`
+	RAW     bool `form:"raw"`
 }
 
 // transform mutates the EntryRequest in place by looking for an entry number in the lemma string.
@@ -42,4 +43,12 @@ type SearchRequest struct {
 
 type SearchResponse struct {
 	Lemmas []string `json:"lemmas"`
+}
+
+type RandomRequest struct {
+	RAW bool `form:"raw"`
+}
+
+type WOTDRequest struct {
+	RAW bool `form:"raw"`
 }

--- a/internal/dictionary/models.go
+++ b/internal/dictionary/models.go
@@ -5,8 +5,8 @@ import (
 )
 
 type AssetData struct {
-	Stats  Stats        `json:"stats"`
-	Lemmas []kbbi.Lemma `json:"lemmas"`
+	Stats  Stats   `json:"stats"`
+	Lemmas []Lemma `json:"lemmas"`
 }
 
 type Stats struct {

--- a/internal/dictionary/models.go
+++ b/internal/dictionary/models.go
@@ -19,7 +19,7 @@ type EntryRequest struct {
 	Lemma string `uri:"entry" validate:"required"`
 	// EntryNo is optional; value 0 means "no specific entry number requested".
 	EntryNo int  `form:"entryNo" validate:"gte=0"`
-	RAW     bool `form:"raw"`
+	Raw     bool `form:"raw"`
 }
 
 // transform mutates the EntryRequest in place by looking for an entry number in the lemma string.
@@ -46,9 +46,9 @@ type SearchResponse struct {
 }
 
 type RandomRequest struct {
-	RAW bool `form:"raw"`
+	Raw bool `form:"raw"`
 }
 
 type WOTDRequest struct {
-	RAW bool `form:"raw"`
+	Raw bool `form:"raw"`
 }

--- a/internal/http/httphandler/handler.go
+++ b/internal/http/httphandler/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
+	"net/url"
 
 	"github.com/gin-gonic/gin"
 	"github.com/raf555/kbbi-api/internal/http/httperr"
@@ -88,8 +89,9 @@ func sendResponse[resT any](ctx *ginCtx, res *resT, err error, opts ...handlerOp
 
 type (
 	RedirectResult struct {
-		Code int
-		Path string
+		Code  int
+		Path  string
+		Query url.Values
 	}
 
 	// RedirectHandler is a simple HTTP request handler which accepts request and redirects into given path.
@@ -123,7 +125,11 @@ func MakeRedirectHandler[reqT any](
 			code = http.StatusTemporaryRedirect
 		}
 
-		gCtx.Redirect(code, result.Path)
+		path := result.Path
+		if len(result.Query) > 0 {
+			path += "?" + result.Query.Encode()
+		}
+		gCtx.Redirect(code, path)
 	}
 }
 

--- a/internal/swagger/docs.go
+++ b/internal/swagger/docs.go
@@ -22,6 +22,14 @@ const docTemplate = `{
                     "entry"
                 ],
                 "summary": "Get Random Lemma",
+                "parameters": [
+                    {
+                        "type": "boolean",
+                        "description": "if raw is true, any rendered unicode character (for 𝗯𝗼𝗹𝗱/𝘪𝘵𝘢𝘭𝘪𝘤/etc) will be replaced by HTML tags instead.",
+                        "name": "raw",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -93,6 +101,14 @@ const docTemplate = `{
                     "entry"
                 ],
                 "summary": "Get Lemma of The Day",
+                "parameters": [
+                    {
+                        "type": "boolean",
+                        "description": "if raw is true, any rendered unicode character (for 𝗯𝗼𝗹𝗱/𝘪𝘵𝘢𝘭𝘪𝘤/etc) will be replaced by HTML tags instead.",
+                        "name": "raw",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -141,6 +157,12 @@ const docTemplate = `{
                         "type": "integer",
                         "description": "Lemma's entry number (optional). Start from 1. Will be skipped if there's entry number in the lemma.",
                         "name": "entryNo",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "if raw is true, any rendered unicode character (for 𝗯𝗼𝗹𝗱/𝘪𝘵𝘢𝘭𝘪𝘤/etc) will be replaced by HTML tags instead.",
+                        "name": "raw",
                         "in": "query"
                     }
                 ],
@@ -237,6 +259,10 @@ const docTemplate = `{
                     "items": {
                         "type": "string"
                     }
+                },
+                "isPrecategorical": {
+                    "description": "IsPrecategorical indicates this entry is categorized into \"prakategorial\" in the dictionary.\nIt means the entry on its own does not have actual meaning until it is given affixes.\nIn our context, that means the entry has empty [Definitions] but has at least one [DerivedWords].\n\nE.g. ` + "`" + `acu (1)` + "`" + `, ` + "`" + `acu (2)` + "`" + `, ` + "`" + `adu domba` + "`" + `.",
+                    "type": "boolean"
                 },
                 "metaphors": {
                     "description": "Metaphors contains metaphors of this entry (if any).\nI.e. ` + "`" + `kiasan` + "`" + `.\nE.g. ` + "`" + `leher` + "`" + ` is used in ` + "`" + `leher terasa panjang` + "`" + ` metaphor.",

--- a/internal/swagger/swagger.json
+++ b/internal/swagger/swagger.json
@@ -11,6 +11,14 @@
                     "entry"
                 ],
                 "summary": "Get Random Lemma",
+                "parameters": [
+                    {
+                        "type": "boolean",
+                        "description": "if raw is true, any rendered unicode character (for 𝗯𝗼𝗹𝗱/𝘪𝘵𝘢𝘭𝘪𝘤/etc) will be replaced by HTML tags instead.",
+                        "name": "raw",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -82,6 +90,14 @@
                     "entry"
                 ],
                 "summary": "Get Lemma of The Day",
+                "parameters": [
+                    {
+                        "type": "boolean",
+                        "description": "if raw is true, any rendered unicode character (for 𝗯𝗼𝗹𝗱/𝘪𝘵𝘢𝘭𝘪𝘤/etc) will be replaced by HTML tags instead.",
+                        "name": "raw",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -130,6 +146,12 @@
                         "type": "integer",
                         "description": "Lemma's entry number (optional). Start from 1. Will be skipped if there's entry number in the lemma.",
                         "name": "entryNo",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "if raw is true, any rendered unicode character (for 𝗯𝗼𝗹𝗱/𝘪𝘵𝘢𝘭𝘪𝘤/etc) will be replaced by HTML tags instead.",
+                        "name": "raw",
                         "in": "query"
                     }
                 ],
@@ -226,6 +248,10 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "isPrecategorical": {
+                    "description": "IsPrecategorical indicates this entry is categorized into \"prakategorial\" in the dictionary.\nIt means the entry on its own does not have actual meaning until it is given affixes.\nIn our context, that means the entry has empty [Definitions] but has at least one [DerivedWords].\n\nE.g. `acu (1)`, `acu (2)`, `adu domba`.",
+                    "type": "boolean"
                 },
                 "metaphors": {
                     "description": "Metaphors contains metaphors of this entry (if any).\nI.e. `kiasan`.\nE.g. `leher` is used in `leher terasa panjang` metaphor.",

--- a/internal/swagger/swagger.yaml
+++ b/internal/swagger/swagger.yaml
@@ -60,6 +60,14 @@ definitions:
         items:
           type: string
         type: array
+      isPrecategorical:
+        description: |-
+          IsPrecategorical indicates this entry is categorized into "prakategorial" in the dictionary.
+          It means the entry on its own does not have actual meaning until it is given affixes.
+          In our context, that means the entry has empty [Definitions] but has at least one [DerivedWords].
+
+          E.g. `acu (1)`, `acu (2)`, `adu domba`.
+        type: boolean
       metaphors:
         description: |-
           Metaphors contains metaphors of this entry (if any).
@@ -168,6 +176,12 @@ paths:
   /api/v1/entry/_random:
     get:
       description: Redirect to the random lemma
+      parameters:
+      - description: "if raw is true, any rendered unicode character (for \U0001D5EF\U0001D5FC\U0001D5F9\U0001D5F1/\U0001D62A\U0001D635\U0001D622\U0001D62D\U0001D62A\U0001D624/etc)
+          will be replaced by HTML tags instead."
+        in: query
+        name: raw
+        type: boolean
       responses:
         "200":
           description: OK
@@ -216,6 +230,12 @@ paths:
   /api/v1/entry/_wotd:
     get:
       description: Redirect to the lemma of the day
+      parameters:
+      - description: "if raw is true, any rendered unicode character (for \U0001D5EF\U0001D5FC\U0001D5F9\U0001D5F1/\U0001D62A\U0001D635\U0001D622\U0001D62D\U0001D62A\U0001D624/etc)
+          will be replaced by HTML tags instead."
+        in: query
+        name: raw
+        type: boolean
       responses:
         "200":
           description: OK
@@ -249,6 +269,11 @@ paths:
         minimum: 1
         name: entryNo
         type: integer
+      - description: "if raw is true, any rendered unicode character (for \U0001D5EF\U0001D5FC\U0001D5F9\U0001D5F1/\U0001D62A\U0001D635\U0001D622\U0001D62D\U0001D62A\U0001D624/etc)
+          will be replaced by HTML tags instead."
+        in: query
+        name: raw
+        type: boolean
       produces:
       - application/json
       responses:

--- a/pkg/kbbi/lemma.go
+++ b/pkg/kbbi/lemma.go
@@ -77,6 +77,13 @@ type (
 		// I.e. `kiasan`.
 		// E.g. `leher` is used in `leher terasa panjang` metaphor.
 		Metaphors []string `json:"metaphors"`
+
+		// IsPrecategorical indicates this entry is categorized into "prakategorial" in the dictionary.
+		// It means the entry on its own does not have actual meaning until it is given affixes.
+		// In our context, that means the entry has empty [Definitions] but has at least one [DerivedWords].
+		//
+		// E.g. `acu (1)`, `acu (2)`, `adu domba`.
+		IsPrecategorical bool `json:"isPrecategorical"`
 	}
 
 	// EntryDefinition contains the detail of the entry's definition.


### PR DESCRIPTION
1. add `isPrecategorical` field to entry struct.

isPrecategorical indicates that an entry is a "prakategorial" as per KBBI dictionary. Which means it does not have definition on its own and only has meaning if given suffixes.

sample

<img width="339" height="527" alt="image" src="https://github.com/user-attachments/assets/e9e2eaf5-5da5-40d5-b363-b87f94de905e" />

in official app

<img width="1229" height="179" alt="image" src="https://github.com/user-attachments/assets/ce653cf5-f4e2-491b-aa59-0375d038bc93" />

2. add `raw` option in entry APIs

by default, the API will return rendered HTML tags such as 𝗯𝗼𝗹𝗱 or 𝘪𝘵𝘢𝘭𝘪𝘤. If the raw option is enabled, it will return `<b>bold</b>` or `<i>italic</i>` instead. Useful for rendering in frontend application that uses HTML.

Some samples

Before

<img width="759" height="488" alt="image" src="https://github.com/user-attachments/assets/64a50b86-f552-4d8f-8bee-c4d9cc737283" />

After

<img width="758" height="491" alt="image" src="https://github.com/user-attachments/assets/6eb17f5a-e87d-4d68-a1ce-f8f5074f0e1e" />


Before

<img width="343" height="234" alt="image" src="https://github.com/user-attachments/assets/c93fb926-706d-4915-b66f-2917ddf47256" />

After

<img width="317" height="232" alt="image" src="https://github.com/user-attachments/assets/ced4de94-194d-46c5-b29d-0c425c2ff334" />


Before

<img width="691" height="331" alt="image" src="https://github.com/user-attachments/assets/56e204c5-8095-4c58-bda6-88216ede36ce" />

After

<img width="740" height="385" alt="image" src="https://github.com/user-attachments/assets/166562bc-2819-4daf-9491-e14a36900304" />

Before

<img width="1415" height="222" alt="image" src="https://github.com/user-attachments/assets/d1cc28d1-3f2f-418e-ad57-63894401b7de" />

After

p.s. this one is unclosed from the KBBI app (faulty HTML tag). But modern browser should be able to resolve this automatically.

<img width="1535" height="239" alt="image" src="https://github.com/user-attachments/assets/9f832f36-a0ca-4954-868f-b849307347ec" />

Before

<img width="914" height="275" alt="image" src="https://github.com/user-attachments/assets/fb1fb3af-9a40-4173-9b4f-1b4939a6663f" />

After

<img width="1378" height="333" alt="image" src="https://github.com/user-attachments/assets/8604fef7-b53c-43c5-880b-4500cde48749" />

Before

<img width="1608" height="117" alt="image" src="https://github.com/user-attachments/assets/9ea879a5-a35d-45cf-9dea-6851c6a83ab1" />

After

<img width="1611" height="120" alt="image" src="https://github.com/user-attachments/assets/99391ea1-2a23-4909-8eb6-09dc19ea872f" />
