### PR TITLE
chore: configurable log level, suppress 4xx logs, fix entry lookup

### DIFF
--- a/internal/dictionary/dictionary.go
+++ b/internal/dictionary/dictionary.go
@@ -133,10 +133,6 @@ func (d *Dictionary) Lemma(lemma string, entryNo int) (Lemma, error) {
 	}
 
 	if entryNo > 0 {
-		if entryNo > len(lemmaData.Entries) {
-			return Lemma{}, ErrEntryNotFound
-		}
-
 		entryIndexes, ok := index.entryNoMap[entryNo]
 		if !ok {
 			return Lemma{}, ErrEntryNotFound

--- a/internal/http/httphandler/handler.go
+++ b/internal/http/httphandler/handler.go
@@ -60,7 +60,12 @@ func sendResponse[resT any](ctx *ginCtx, res *resT, err error, opts ...handlerOp
 	statusCodeMessage := http.StatusText(statusCode)
 
 	if err != nil {
-		logger.FromContext(ctx).ErrorContext(ctx, "HTTP error occurred", logger.Error(err), slog.Int("code", statusCode))
+		l := logger.FromContext(ctx)
+		logFn := l.ErrorContext
+		if statusCode >= 400 && statusCode < 500 {
+			logFn = l.WarnContext
+		}
+		logFn(ctx, "HTTP error occurred", logger.Error(err), slog.Int("code", statusCode))
 
 		innerErrMsg := statusCodeMessage
 

--- a/internal/logger/config.go
+++ b/internal/logger/config.go
@@ -1,0 +1,7 @@
+package logger
+
+import "log/slog"
+
+type Config struct {
+	Level slog.Level `env:"LOG_LEVEL,default=INFO"`
+}

--- a/internal/logger/loggerfx/logger.go
+++ b/internal/logger/loggerfx/logger.go
@@ -7,11 +7,13 @@ import (
 	contexts "github.com/raf555/kbbi-api/internal/context"
 	"github.com/raf555/kbbi-api/internal/context/contextfx"
 	"github.com/raf555/kbbi-api/internal/logger"
+	salomeconfig "github.com/raf555/salome/config/v1"
 	"go.uber.org/fx"
 )
 
 var Provider = fx.Module(
 	"logger",
+	fx.Provide(salomeconfig.LoadConfigTo[logger.Config], fx.Private),
 	fx.Provide(logger.New),
 	contextfx.Provider(func(log *slog.Logger) contexts.ContextDecoratorFn {
 		return func(ctx context.Context) context.Context {

--- a/internal/logger/slog.go
+++ b/internal/logger/slog.go
@@ -8,10 +8,10 @@ import (
 	slogformatter "github.com/samber/slog-formatter"
 )
 
-func New() *slog.Logger {
+func New(cfg Config) *slog.Logger {
 	var handler slog.Handler
 
-	handler = slog.NewJSONHandler(os.Stdout, nil)
+	handler = slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: cfg.Level})
 	handler = log.WithOtelHandler(handler)
 	handler = log.WithFormatter(handler, slogformatter.FormatByKind(slog.KindDuration, func(v slog.Value) slog.Value {
 		return slog.StringValue(v.Duration().String())


### PR DESCRIPTION
## Summary

- Add `LOG_LEVEL` env var support to configure slog level at runtime (defaults to `INFO`)
- Downgrade HTTP 4xx responses from `Error` to `Warn` log level; client errors shouldn't 
  trigger server-error alerts
- Fix incorrect bounds check in dictionary entry lookup that compared against total entries 
  instead of the entry number map, causing false `ErrEntryNotFound` returns