### PR TITLE
chore(dictionary): make inverse index map to use struct instead of ptr

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    uses: raf555/actions/.github/workflows/build-ghcr.yaml@v1
+    uses: raf555/actions/.github/workflows/build-ghcr.yaml@v1.1
     permissions:
       contents: read
       packages: write

--- a/internal/dictionary/dictionary.go
+++ b/internal/dictionary/dictionary.go
@@ -15,8 +15,8 @@ type Dictionary struct {
 	wotd                   WOTDRepo
 	stats                  Stats
 	longestLemmaLength     int
-	inverseIndex           map[string]*lemmaIndex
-	inverseNormalizedIndex map[string]*lemmaIndex
+	inverseIndex           map[string]lemmaIndex
+	inverseNormalizedIndex map[string]lemmaIndex
 	lemmas                 []wrappedLemma
 }
 
@@ -52,12 +52,12 @@ func NewDictionary(cfg Configuration, logger *slog.Logger, wotd WOTDRepo) (*Dict
 	logger.Info("Finished reading dictionary asset", slog.String("elapsed", time.Since(start).String()))
 
 	longestLemmaLength := 0
-	inverseIdx := make(map[string]*lemmaIndex, len(assetData.Lemmas))
-	inverseNormalizedIndex := make(map[string]*lemmaIndex)
+	inverseIdx := make(map[string]lemmaIndex, len(assetData.Lemmas))
+	inverseNormalizedIndex := make(map[string]lemmaIndex)
 	lemmas := make([]wrappedLemma, 0, len(assetData.Lemmas))
 
 	for i, lemma := range assetData.Lemmas {
-		idx := &lemmaIndex{
+		idx := lemmaIndex{
 			idx:        i,
 			entryNoMap: map[int][]int{},
 		}
@@ -150,14 +150,14 @@ func (d *Dictionary) lookupInverseIndex(lemma string) *lemmaIndex {
 	// lookup on exact index first
 	index, ok := d.inverseIndex[lemma]
 	if ok {
-		return index
+		return &index
 	}
 
 	// if not found, normalize the lemma, and check on the normalized index
 	normalized := Normalize(lemma, false)
 	index, ok = d.inverseNormalizedIndex[normalized]
 	if ok {
-		return index
+		return &index
 	}
 
 	// otherwise not found

--- a/internal/dictionary/dictionary.go
+++ b/internal/dictionary/dictionary.go
@@ -58,9 +58,10 @@ func NewDictionary(cfg Configuration, logger *slog.Logger, wotd WOTDRepo) (*Dict
 
 	for i, lemma := range assetData.Lemmas {
 		idx := lemmaIndex{
-			idx:        i,
-			entryNoMap: map[int][]int{},
+			idx: i,
 		}
+
+		entryNoMap := map[int][]int{}
 
 		// lookup and map entry index if any
 		for j, def := range lemma.Entries {
@@ -71,7 +72,11 @@ func NewDictionary(cfg Configuration, logger *slog.Logger, wotd WOTDRepo) (*Dict
 
 			// there can be multiple entries with same number. E.g. ketak (4)
 			// could be misinput from KBBI but for now making the behavior the same as the website.
-			idx.entryNoMap[entryNo] = append(idx.entryNoMap[entryNo], j)
+			entryNoMap[entryNo] = append(entryNoMap[entryNo], j)
+		}
+
+		if len(entryNoMap) > 0 {
+			idx.entryNoMap = entryNoMap
 		}
 
 		inverseIdx[lemma.Lemma] = idx
@@ -121,8 +126,8 @@ func (d *Dictionary) Lemma(lemma string, entryNo int) (Lemma, error) {
 		return Lemma{}, ErrLemmaTooLong
 	}
 
-	index := d.lookupInverseIndex(lemma)
-	if index == nil {
+	index, ok := d.lookupInverseIndex(lemma)
+	if !ok {
 		return Lemma{}, ErrLemmaNotFound
 	}
 
@@ -146,22 +151,22 @@ func (d *Dictionary) Lemma(lemma string, entryNo int) (Lemma, error) {
 	return lemmaData.Lemma, nil
 }
 
-func (d *Dictionary) lookupInverseIndex(lemma string) *lemmaIndex {
+func (d *Dictionary) lookupInverseIndex(lemma string) (lemmaIndex, bool) {
 	// lookup on exact index first
 	index, ok := d.inverseIndex[lemma]
 	if ok {
-		return &index
+		return index, true
 	}
 
 	// if not found, normalize the lemma, and check on the normalized index
 	normalized := Normalize(lemma, false)
 	index, ok = d.inverseNormalizedIndex[normalized]
 	if ok {
-		return &index
+		return index, true
 	}
 
 	// otherwise not found
-	return nil
+	return lemmaIndex{}, false
 }
 
 func (d *Dictionary) RandomLemma() Lemma {


### PR DESCRIPTION
the inverse indexes lives in the heap with hundred of thousands objects, giving the GC some extra pressures, although not much

since the struct is small anyway, making it as struct instead of pointer to reduce number of live objects in the heap.

Quick run shows a slight improvement, although not much.

<img width="1816" height="725" alt="image" src="https://github.com/user-attachments/assets/f14afe78-90e5-45f4-9c16-96f98fc7b70f" />
